### PR TITLE
Avoid deb packages upload from the pull requests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,6 +46,8 @@ steps:
     target: /repo/assurio-snap/${DRONE_BRANCH}/deb
     strip_prefix: repobuild/deb/repo/
     exclude: ./**/*GPG-KEY
+    when:
+      event: push
 
 - name: upload gpg pub key
   image: plugins/s3
@@ -61,6 +63,9 @@ steps:
     source: repobuild/deb/repo/ASSURIO-PKGS-GPG-KEY
     target: /repo
     strip_prefix: repobuild/deb/repo/
+    when:
+      branch: master
+      event: push
 
 ---
 kind: pipeline


### PR DESCRIPTION
The packages for a commit for some particular branch are already uploaded to the `...${DRONE_BRANCH}/deb` after a commit was pushed to a branch and before PR has been created. And no need to make upload one more time from a PR.