### PR TITLE
Multiple improvements for the CentOS repository build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,14 +69,14 @@ steps:
 
 ---
 kind: pipeline
-name: centos6_packaging
+name: centos_packaging
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-- name: build packages
+- name: build CentOS 6 packages
   image: centos:6.10
 
   environment:
@@ -90,6 +90,44 @@ steps:
   commands:
     # Step 1: Prepare container
     - yum install -y git gcc rsync rpm-build createrepo expect tree
+    # Step 2: Build rpm packages
+    - make rpm
+    # Step 3: Generate package repo
+    - repobuild/rpm/gen-repo.sh
+
+- name: build CentOS 7 packages
+  image: centos:7.0.1406
+
+  environment:
+    GPG_KEY_ID:
+      from_secret: GPG_KEY_ID
+    GPG_PUB_KEY:
+      from_secret: GPG_PUB_KEY
+    GPG_PRIV_KEY:
+      from_secret: GPG_PRIV_KEY
+
+  commands:
+    # Step 1: Prepare container
+    - yum install -y git gcc make rsync rpm-build rpm-sign createrepo expect tree
+    # Step 2: Build rpm packages
+    - make rpm
+    # Step 3: Generate package repo
+    - repobuild/rpm/gen-repo.sh
+
+- name: build CentOS 8 packages
+  image: centos:8
+
+  environment:
+    GPG_KEY_ID:
+      from_secret: GPG_KEY_ID
+    GPG_PUB_KEY:
+      from_secret: GPG_PUB_KEY
+    GPG_PRIV_KEY:
+      from_secret: GPG_PRIV_KEY
+
+  commands:
+    # Step 1: Prepare container
+    - yum install -y git gcc make rsync rpm-build rpm-sign createrepo expect tree
     # Step 2: Build rpm packages
     - make rpm
     # Step 3: Generate package repo

--- a/.drone.yml
+++ b/.drone.yml
@@ -46,8 +46,8 @@ steps:
     target: /repo/assurio-snap/${DRONE_SOURCE_BRANCH}/deb
     strip_prefix: repobuild/deb/repo/
     exclude: ./**/*GPG-KEY
-    when:
-      event: push
+  when:
+    event: push
 
 - name: upload gpg pub key
   image: plugins/s3
@@ -63,9 +63,9 @@ steps:
     source: repobuild/deb/repo/ASSURIO-PKGS-GPG-KEY
     target: /repo
     strip_prefix: repobuild/deb/repo/
-    when:
-      branch: master
-      event: push
+  when:
+    branch: master
+    event: push
 
 ---
 kind: pipeline
@@ -109,5 +109,5 @@ steps:
     source: repobuild/rpm/repo/**/*
     target: /repo/assurio-snap/${DRONE_SOURCE_BRANCH}/rpm
     strip_prefix: repobuild/rpm/repo/
-    when:
-      event: push
+  when:
+    event: push

--- a/repobuild/rpm/gen-repo.sh
+++ b/repobuild/rpm/gen-repo.sh
@@ -9,10 +9,12 @@ die () {
 
 dir=$(readlink -f $(dirname $0))
 out=$dir/repo
-cent6=$out/CentOS/6
-pool=$cent6/x86_64/Packages
+dist_ver=`cat /etc/redhat-release | tr -cd [0-9.] | cut -d'.' -f1`
+cent=$out/CentOS/$dist_ver/x86_64
+pool=$cent/Packages
+mirrors=$out/CentOS/mirrors
 branch=`git rev-parse --abbrev-ref HEAD`
-bucket=ci.assur.io
+repo_link=https://repo.assur.io/assurio-snap
 
 [ -z "$GPG_KEY_ID" ]   && die "Env var GPG_KEY_ID is not set"
 [ -z "$GPG_PUB_KEY" ]  && die "Env var GPG_PUB_KEY is not set"
@@ -26,9 +28,9 @@ gpg2 --list-secret-key $GPG_KEY_ID >/dev/null || \
      die "Failed to import gpg key"
 
 # Cleanup and prepare dir structure
-rm -rf $out
-mkdir -p $cent6/x86_64/{Packages,repodata}
-mkdir -p $out/CentOS/mirrors
+rm -rf $cent $mirrors/$dist_ver*
+mkdir -p $cent/{Packages,repodata}
+mkdir -p $mirrors
 
 # Prepare 'Packages' dir. It's analog of the 'pool' dir for deb
 cp -r $dir/../../pkgbuild/RPMS/x86_64/* $pool
@@ -44,18 +46,16 @@ for f in `ls $pool/*.rpm`; do
 done
 
 # Generate repodata/repomd.xml
-createrepo $cent6/x86_64 || die "Failed to create repomd.xml"
+createrepo $cent || die "Failed to create repomd.xml"
 
 # Sign repository (repomd.xml files)
-gpg2 --default-key $GPG_KEY_ID --batch --yes --no-tty --armor --digest-algo SHA256 --detach-sign $cent6/x86_64/repodata/repomd.xml || \
+gpg2 --default-key $GPG_KEY_ID --batch --yes --no-tty --armor --digest-algo SHA256 --detach-sign $cent/repodata/repomd.xml || \
     die "Failed to sign repomd.xml file."
 
 # Generate 'mirrors'
-mirrors_content="http://$bucket.s3.amazonaws.com/repo/assurio-snap/$branch/rpm/CentOS/6/\$basearch"
-for ver in 6 7 8; do
-    for kind in '' 'Client' 'Server' 'Workstation'; do
-        echo $mirrors_content > $out/CentOS/mirrors/$ver$kind
-    done
+mirrors_content="$repo_link/$branch/rpm/CentOS/\$releasever/\$basearch"
+for kind in '' 'Client' 'Server' 'Workstation'; do
+    echo $mirrors_content > $mirrors/$dist_ver$kind
 done
 
 # Show repo's tree to the log

--- a/repobuild/rpm/rpm-sign.exp
+++ b/repobuild/rpm/rpm-sign.exp
@@ -1,7 +1,16 @@
 #!/usr/bin/expect
+
 spawn rpm --addsign [lindex $argv 0]
-expect -exact "Enter pass phrase: "
-send -- "\n\r"
-expect eof
+
+# CentOS 6 and 7 asks for passphrase and then send eof
+# CentOS 8 just sends eof
+expect {
+    -exact "Enter pass phrase: " {
+        send -- "\n\r"
+        # continue to wait for eof after passphrase
+        exp_continue
+    }
+    eof
+}
 catch wait result
 exit [lindex $result 3]

--- a/repobuild/rpm/rpm-sign.exp
+++ b/repobuild/rpm/rpm-sign.exp
@@ -3,3 +3,5 @@ spawn rpm --addsign [lindex $argv 0]
 expect -exact "Enter pass phrase: "
 send -- "\n\r"
 expect eof
+catch wait result
+exit [lindex $result 3]


### PR DESCRIPTION
1) Fixed build conditions in the yaml script to avoid packages upload
in the PR builds.
Tabulation in the .drone.yml was wrong. "when" word was related to
the build step settings, but not to the build step.

2) Added error handling to the rpm repo build script.

3) Added mirror files for CentOS 6, 7, 8 since CentOS 6 packages
installabe on the newer CentOS versions.