### PR TITLE
Add builds for Fedora 31, Amazon Linux 2, Debian 9, 10

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,13 +1,49 @@
 kind: pipeline
-name: debian_jessie_packaging
+name: deb_packaging
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-- name: build packages
+- name: build Debian Jessie packages
   image: debian:jessie
+
+  commands:
+    # Step 1: Prepare container
+    - apt-get update &&
+        apt-get install -y build-essential rsync git pax apt-utils tree
+        gnupg2 dpkg-sig
+    - dir=`pwd` && cd / &&
+        git clone https://github.com/debbuild/debbuild.git &&
+        cd /debbuild &&
+        ./configure && make && make install &&
+        cd $dir
+    # Step 2: Build deb packages
+    - make deb
+    # Step 3: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: build Debian Stretch packages
+  image: debian:stretch
+
+  commands:
+    # Step 1: Prepare container
+    - apt-get update &&
+        apt-get install -y build-essential rsync git pax apt-utils tree
+        gnupg2 dpkg-sig
+    - dir=`pwd` && cd / &&
+        git clone https://github.com/debbuild/debbuild.git &&
+        cd /debbuild &&
+        ./configure && make && make install &&
+        cd $dir
+    # Step 2: Build deb packages
+    - make deb
+    # Step 3: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: build Debian Buster packages
+  image: debian:buster
 
   commands:
     # Step 1: Prepare container
@@ -43,7 +79,7 @@ steps:
 
 ---
 kind: pipeline
-name: centos_packaging
+name: rpm_packaging
 
 platform:
   os: linux
@@ -74,6 +110,28 @@ steps:
 
 - name: build CentOS 8 packages
   image: centos:8
+
+  commands:
+    # Step 1: Prepare container
+    - yum install -y gcc make rsync rpm-build tree
+    # Step 2: Build rpm packages
+    - make rpm
+    # Step 3: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: build Fedora 31 packages
+  image: fedora:31
+
+  commands:
+    # Step 1: Prepare container
+    - yum install -y gcc make rsync rpm-build tree
+    # Step 2: Build rpm packages
+    - make rpm
+    # Step 3: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: build Amazon Linux 2 packages
+  image: amazonlinux:2
 
   commands:
     # Step 1: Prepare container
@@ -148,5 +206,5 @@ steps:
     event: push
 
 depends_on:
-- debian_jessie_packaging
-- centos_packaging
+- deb_packaging
+- rpm_packaging

--- a/repobuild/collect_artifacts.sh
+++ b/repobuild/collect_artifacts.sh
@@ -3,6 +3,18 @@
 dir=$(readlink -f $(dirname $0))
 out=$dir/artifacts
 
+declare -A COPY_DIRS
+COPY_DIRS[rpm]="RPMS/x86_64 RPMS/noarch SRPMS"
+COPY_DIRS[deb]="DEBS/**"
+
+declare -A POOLS
+POOLS[rpm]="x86_64/Packages"
+POOLS[deb]="pool"
+
+# system-release should be last, it's present on all rpm systems
+# and it's used here for amazon linux detection
+declare -a RELEASE_FILES=("centos-release" "fedora-release" "debian_version" "system-release")
+
 # Make 'info' file with the artifacts details
 make_info () {
 if [ -z "$DRONE_BUILD_NUMBER" ]; then
@@ -20,18 +32,27 @@ Build:      $DRONE_BUILD_NUMBER
 INFO
 }
 
-if [ -f "/etc/redhat-release" ]; then
-    dist_ver=`cat /etc/redhat-release | tr -cd [0-9.] | cut -d'.' -f1`
-    pool=$out/CentOS/$dist_ver/x86_64/Packages
-    copy_dirs=(RPMS/{x86_64,noarch} SRPMS)
-elif [ -f "/etc/debian_version" ]; then
-    pool=$out/Debian/pool
-    copy_dirs="DEBS/**"
-    make_info
-else
+# Expected dist_name-s: Amazon CentOS Fedora
+dist_name=`cat /etc/system-release 2>/dev/null | cut -d' ' -f1`
+dist_ver=
+pkg_type=rpm
+for file in "${RELEASE_FILES[@]}"; do
+    if [ -f "/etc/$file" ]; then
+        # Expected dist_name-s: Debian CentOS Fedora
+        [ -z "$dist_name" ] && dist_name=`d=${file^} && echo ${d//os/OS} | cut -d'-' -f1 | cut -d'_' -f1`
+        dist_ver=`cat /etc/$file | tr -cd '[0-9.]' | cut -d'.' -f1`
+        [ "$file" == "debian_version" ] && pkg_type="deb" && make_info
+        break
+    fi
+done
+
+if [ -z $dist_ver ] || [ -z $dist_name ]; then
     echo "Unknown Linux distro"
     exit 1
 fi
+
+pool=$out/$dist_name/$dist_ver/${POOLS[$pkg_type]}
+copy_dirs=(${COPY_DIRS[$pkg_type]})
 
 # Cleanup and prepare dir structure
 rm -rf $pool


### PR DESCRIPTION
- repobuild/collect_artifacts.sh is more universal now. It can collect
artifacts of the different Debian, Fedora, Amazon Linux versions.
- Fixed a mistake when detecting distro ver.

Resolves #9