### PR TITLE
Fix an error message during kernel module installation

### DIFF
--- a/src/configure-tests/feature-tests/Makefile
+++ b/src/configure-tests/feature-tests/Makefile
@@ -18,5 +18,5 @@ $(BUILDDIR):
 $(BUILDDIR_MAKEFILE): $(BUILDDIR)
 	touch "$@"
 
-clean:
+clean: $(BUILDDIR)
 	$(MAKE) -C $(KDIR) M=$(BUILDDIR) src=$(PWD) clean


### PR DESCRIPTION
There was a message like 'find: .../build/configure-tests/feature-tests/build/ No such file or directory'
During the dkms build of the kernel module sources.
As it turned out, this doesn't affect feature tests build and execution. Because it's happens just on the 'clean' target when is nothing to clean. It's an installation of the kernel module package or first clean dkms build. But anyway it's fixed.

Resolves #13 
