### PR TITLE
Use drone exec runners for the packages build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,193 +1,319 @@
+env: &env
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+
 kind: pipeline
-name: deb_packaging
+name: Debian 8
+type: exec
 
 platform:
   os: linux
   arch: amd64
+
+node:
+  distro: debian8
 
 steps:
 - name: build Debian Jessie packages
-  image: debian:jessie
-
   commands:
-    # Step 1: Prepare container
-    - apt-get update &&
-        apt-get install -y build-essential rsync git pax apt-utils tree
-        gnupg2 dpkg-sig
-    - dir=`pwd` && cd / &&
-        git clone https://github.com/debbuild/debbuild.git &&
-        cd /debbuild &&
-        ./configure && make && make install &&
-        cd $dir
-    # Step 2: Build deb packages
+    # Step 1: Build deb packages
     - make deb
-    # Step 3: Collect artifacts
+    # Step 2: Collect artifacts
     - repobuild/collect_artifacts.sh
 
-- name: build Debian Stretch packages
-  image: debian:stretch
-
+- name: Upload artifacts
+  <<: *env
   commands:
-    # Step 1: Prepare container
-    - apt-get update &&
-        apt-get install -y build-essential rsync git pax apt-utils tree
-        gnupg2 dpkg-sig
-    - dir=`pwd` && cd / &&
-        git clone https://github.com/debbuild/debbuild.git &&
-        cd /debbuild &&
-        ./configure && make && make install &&
-        cd $dir
-    # Step 2: Build deb packages
-    - make deb
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: build Debian Buster packages
-  image: debian:buster
-
-  commands:
-    # Step 1: Prepare container
-    - apt-get update &&
-        apt-get install -y build-essential rsync git pax apt-utils tree
-        gnupg2 dpkg-sig
-    - dir=`pwd` && cd / &&
-        git clone https://github.com/debbuild/debbuild.git &&
-        cd /debbuild &&
-        ./configure && make && make install &&
-        cd $dir
-    # Step 2: Build deb packages
-    - make deb
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: upload artifacts
-  image: plugins/s3
-  settings:
-    bucket: artifacts.assur.io
-    acl: private
-    access_key:
-      from_secret: AWS_ACCESS_KEY_ID
-    secret_key:
-      from_secret: AWS_SECRET_ACCESS_KEY
-    region:
-      from_secret: AWS_REGION
-    source: repobuild/artifacts/**/*
-    target: /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/deb
-    strip_prefix: repobuild/artifacts
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/deb
+      --exclude *GPG-KEY
   when:
     event: push
 
----
-kind: pipeline
-name: rpm_packaging
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: build CentOS 6 packages
-  image: centos:6.10
-
-  commands:
-    # Step 1: Prepare container
-    - yum install -y gcc rsync rpm-build tree
-    # Step 2: Build rpm packages
-    - make rpm
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: build CentOS 7 packages
-  image: centos:7.0.1406
-
-  commands:
-    # Step 1: Prepare container
-    - yum install -y gcc make rsync rpm-build tree
-    # Step 2: Build rpm packages
-    - make rpm
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: build CentOS 8 packages
-  image: centos:8
-
-  commands:
-    # Step 1: Prepare container
-    - yum install -y gcc make rsync rpm-build tree
-    # Step 2: Build rpm packages
-    - make rpm
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: build Fedora 31 packages
-  image: fedora:31
-
-  commands:
-    # Step 1: Prepare container
-    - yum install -y gcc make rsync rpm-build tree
-    # Step 2: Build rpm packages
-    - make rpm
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: build Amazon Linux 2 packages
-  image: amazonlinux:2
-
-  commands:
-    # Step 1: Prepare container
-    - yum install -y gcc make rsync rpm-build tree
-    # Step 2: Build rpm packages
-    - make rpm
-    # Step 3: Collect artifacts
-    - repobuild/collect_artifacts.sh
-
-- name: upload artifacts
-  image: plugins/s3
-  settings:
-    bucket: artifacts.assur.io
-    acl: private
-    access_key:
-      from_secret: AWS_ACCESS_KEY_ID
-    secret_key:
-      from_secret: AWS_SECRET_ACCESS_KEY
-    region:
-      from_secret: AWS_REGION
-    source: repobuild/artifacts/**/*
-    target: /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/rpm
-    strip_prefix: repobuild/artifacts
-  when:
-    event: push
-
----
-kind: pipeline
-name: trigger_repo_build
-
-platform:
-  os: linux
-  arch: amd64
-
-steps:
-- name: make artifacts manifest
-  image: debian:jessie
+- name: Make artifacts manifest
   commands:
     - echo ${DRONE_BUILD_NUMBER} >> latest
 
-- name: upload artifacts manifest
-  image: plugins/s3
-  settings:
-    bucket: artifacts.assur.io
-    acl: private
-    access_key:
-      from_secret: AWS_ACCESS_KEY_ID
-    secret_key:
-      from_secret: AWS_SECRET_ACCESS_KEY
-    region:
-      from_secret: AWS_REGION
-    source: latest
-    target: /linux/assurio-snap/${DRONE_SOURCE_BRANCH}
+- name: Upload artifacts manifest
+  <<: *env
+  commands:
+    - repobuild/upload.sh
+      --source latest
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}
   when:
     event: push
 
+---
+kind: pipeline
+name: Debian 9
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: debian9
+
+steps:
+- name: build Debian Stretch packages
+  commands:
+    # Step 1: Build deb packages
+    - make deb
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/deb
+      --exclude *GPG-KEY
+  when:
+    event: push
+
+---
+kind: pipeline
+name: Debian 10 
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: debian10
+
+steps:
+- name: build Debian Buster packages
+  commands:
+    # Step 1: Build deb packages
+    - make deb
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/deb
+      --exclude *GPG-KEY
+  when:
+    event: push
+
+---
+kind: pipeline
+name: CentOS 6
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: centos6
+
+steps:
+- name: build CentOS 6 packages
+  commands:
+    # Step 1: Build rpm packages
+    - make rpm
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/rpm
+  when:
+    event: push
+
+---
+kind: pipeline
+name: CentOS 7
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: centos7
+
+steps:
+- name: build CentOS 7 packages
+  commands:
+    # Step 1: Build rpm packages
+    - make rpm
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/rpm
+  when:
+    event: push
+
+---
+kind: pipeline
+name: CentOS 8
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: centos8
+
+steps:
+- name: build CentOS 8 packages
+  commands:
+    # Step 1: Build rpm packages
+    - make rpm
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/rpm
+  when:
+    event: push
+
+---
+kind: pipeline
+name: Fedora 31
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: fedora31
+
+steps:
+- name: build Fedora 31 packages
+  commands:
+    # Step 1: Build rpm packages
+    - make rpm
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/rpm
+  when:
+    event: push
+
+---
+kind: pipeline
+name: Amazon Linux 2
+type: exec
+
+platform:
+  os: linux
+  arch: amd64
+
+node:
+  distro: amazon2
+
+steps:
+- name: build Amazon Linux 2 packages
+  commands:
+    # Step 1: Build rpm packages
+    - make rpm
+    # Step 2: Collect artifacts
+    - repobuild/collect_artifacts.sh
+
+- name: Upload artifacts
+  environment:
+    AWS_ACCESS_KEY_ID:
+      from_secret: AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY:
+      from_secret: AWS_SECRET_ACCESS_KEY
+    AWS_DEFAULT_REGION:
+      from_secret: AWS_REGION
+  commands:
+    - repobuild/upload.sh
+      --source repobuild/artifacts/
+      --bucket artifacts.assur.io
+      --target /linux/assurio-snap/${DRONE_SOURCE_BRANCH}/${DRONE_BUILD_NUMBER}/rpm
+  when:
+    event: push
+
+---
+kind: pipeline
+name: Trigger repo build
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
 - name: trigger
   image: plugins/downstream
   # This step fails when 'packaging' hasn't a branch with the
@@ -206,5 +332,11 @@ steps:
     event: push
 
 depends_on:
-- deb_packaging
-- rpm_packaging
+- Debian 8
+- Debian 9 
+- Debian 10
+- CentOS 6
+- CentOS 7
+- CentOS 8
+- Fedora 31
+- Amazon Linux 2

--- a/repobuild/upload.sh
+++ b/repobuild/upload.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+me=$(basename $0)
+dir=$(readlink -f $(dirname $0))
+
+usage()
+{
+    echo "This script uploads files to an s3 bucket."
+    echo "Usage example: $me -s /path/to/source/files/* -b my-s3-bucket -t /path/in/the/bucket [-e ./**/exclude_files] [-n '*no-cache-files*'] [-t my_tag=some_value] -acl-public | -h"
+    echo
+    echo "  -s | --source          : Source loacation of the packages, like 'linux/repo/artifacts/deb/'. The relative path from the current directory."
+    echo "  -b | --bucket          : Target bucket name."
+    echo "  -t | --target          : Target directory of the packages in the s3 bucket, like '/repo/linux/\${DRONE_SOURCE_BRANCH}/deb'."
+    echo "  -m | --mask            : Optional. Single mask as '-name' param for the 'find' command to filter file(s) in the source location."
+    echo "  -e | --exclude         : Optional. A mask or list of comma-separated masks to exclude files from the '--source' path,"
+    echo "                           like '*GPG-KEY', to not upload them."
+    echo "  -n | --no-cache        : Optioanl. Some mask or list of comma-separated masks to distinct files from the source files,"
+    echo "                           wich will be uploaded with the header 'Cache-Control: max-age=0'."
+    echo "                           It could be something like '*Release*;*repo*' to exclude Release, InRelease, repo package etc."
+    echo "                           These files aren't cached by Cloudfront."
+    echo "  -t | --tag             : Optional. Add an s3 tag to all uploaded files. It looks like tag_name:subname=tag_value. DO NOT USE SPACES!!!"
+    echo "  -p | --prefix-strip    : Optional. A part of the source path to strip when copying files to the target."
+    echo "  -a | --acl-public      : Optional, without parameter. Use s3 ACL public-read for uploaded files. Private is default, if this arg is not specified."
+    echo "  -o | --delete-outdated : Optional, without parameter. Remove obsolete files, present in the target location before the upload and not rewritten by new files."
+    echo "  -h | --help            : Show this usage help."
+}
+
+# 1st arg - path to prettify
+# 2nd arg - yes - remove leading slash, if present
+# 3rd arg - yes - remove trailing slash, if present
+prettify_path()
+{
+    local ret=`echo "${1}" | sed 's#//*#/#g'`
+
+    if [ $ret != '/' ] && [ $ret != './' ]; then
+        [[ "$2" == "yes" ]] && ret=`echo "${ret#/}"`
+        [[ "$3" == "yes" ]] && ret=`echo "${ret%/}"`
+    fi
+    echo $ret
+}
+
+[ "$1" == "" ] && echo "Script need some arguments!" && usage && exit 1
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -s | --source)          shift && src=$(prettify_path $1 no yes) ;;
+        -a | --acl-public)      acl="--acl public-read" ;;
+        -b | --bucket)          shift && bucket="$1" ;;
+        -t | --target)          shift && target=$(prettify_path $1 yes yes) ;;
+        -m | --mask)            shift && mask="$1" ;;
+        -e | --exclude)         shift && exclude="$1" ;;
+        -n | --no-cache)        shift && no_cache="$1" ;;
+        -t | --tag)             shift && tag="$1" ;;
+        -p | --prefix-strip)    shift && strip_prefix=$(prettify_path $1 yes yes) ;;
+        -o | --delete-outdated) del_olds=1 ;;
+        -h | --help)            usage && exit ;;
+        *)                      echo "Wrong arguments!"
+                                echo
+                                usage && exit 15 ;;
+    esac
+    shift
+done
+
+if [ -z "$src" ]; then
+    echo "Missing '-s' arg which is source loacation of the packages."
+    usage
+    exit 2
+fi
+
+if [ ! -d $src ] && [ ! -f $src ] ; then
+    echo "The source file or directory $src doesn't exist."
+    exit 3
+fi
+
+if [ -z "$bucket" ]; then
+    echo "Missing '-b' arg which is bucket name."
+    usage
+    exit 4
+fi
+
+if [ -z "$target" ]; then
+    echo "Missing '-t' arg which is target directory of the packages in the s3 bucket."
+    usage
+    exit 5
+fi
+
+if [ ! -z "$exclude" ]; then
+    for excl in ${exclude//,/ }; do
+        exclusions="$exclusions ! -name $excl "
+    done
+fi
+
+[ ! -z "$mask" ] && mask="-name $mask"
+[ -z "$acl" ] && acl="--acl private"
+
+files=($(find $src $mask $exclusions -type f))
+
+if [ ! -z "$del_olds" ]; then
+    old_files=($(aws s3 ls --recursive s3://$bucket/$target/ | tr -s ' ' | awk -F"$target/" '{print $2}'))
+fi
+
+if [ ! -z "$tag" ]; then
+    tag="--tagging $tag"
+fi
+
+if [ ! -z "$no_cache" ]; then
+    for f in ${no_cache//,/ }; do
+        f_nc=($(find $src -name $f -type f))
+        [ $f_nc ] && files_no_cache+=(${f_nc[@]})
+    done
+fi
+
+for file in ${files[@]}; do
+
+    dest_file=${file#"$src/"}
+    [ ! -z $strip_prefix ] && dest_file=${dest_file#"$strip_prefix/"}
+
+    nc=
+    if [[ "${files_no_cache[@]}" =~ "$file" ]]; then
+        nc="--cache-control max-age=0"
+    fi
+
+    out=$target/$dest_file
+    if [ $target == '/' ] || [ $target == './' ]; then
+        out=$dest_file
+    fi
+
+    set -x
+    aws s3api put-object $acl $nc $tag --body $file --bucket $bucket --key $out || exit 7
+    { set +x; } 2>/dev/null
+    old_files=("${old_files[*]/$dest_file}")
+done
+
+if [ ! -z "$del_olds" ]; then
+    echo "Removing obsolete files, present in the s3://$bucket/$target before upload."
+    for file in ${old_files[@]}; do
+        aws s3 rm s3://$bucket/$target/$file || exit 6
+    done
+fi


### PR DESCRIPTION
Now each build is separate pipeline due to exec runner limitations.
Added upload script which is used instead of the drone s3 plugin.
Drone "downstream" plugin is still used to trigger packaging build.