### PR TITLE
[Internal/CI] Use OIDC role-based auth for upload manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          role-to-assume: ${{ secrets.ASSURIODEV_OIDC_AWS_ROLE_ARN }}
+
       - name: Make manifest
         run: echo $GITHUB_RUN_NUMBER > latest && cat latest | grep -E '^[0-9]+$'
 


### PR DESCRIPTION
This was overlooked in the prev [similar fix](https://github.com/elastio/elastio-snap/pull/222).
And upload manifest step was [broken](https://github.com/elastio/elastio-snap/actions/runs/4426448952/jobs/7763933865).